### PR TITLE
Fix #42

### DIFF
--- a/apps/pages/context_processors.py
+++ b/apps/pages/context_processors.py
@@ -1,0 +1,24 @@
+from .models import UserProfile
+
+
+def user_profile(request):
+    """Add the authenticated user's profile and display name to the context."""
+
+    user = getattr(request, "user", None)
+
+    if user is None or not user.is_authenticated:
+        return {"user_profile": None, "user_display_name": None}
+
+    profile = None
+
+    try:
+        profile = UserProfile.objects.select_related("user").get(user=user)
+    except UserProfile.DoesNotExist:
+        profile = None
+
+    if profile and profile.display_name:
+        display_name = profile.display_name
+    else:
+        display_name = user.get_full_name() or user.get_username()
+
+    return {"user_profile": profile, "user_display_name": display_name}

--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -10,7 +10,7 @@ class UserProfile(models.Model):
     ]
 
     user = models.OneToOneField(User, on_delete=models.CASCADE)
-    display_name = models.CharField(max_length=100, blank=True)
+    display_name = models.CharField(max_length=100, blank=False)
     household_size = models.PositiveIntegerField(default=1)  # Default to 1 person
     house_type = models.CharField(
         max_length=10, choices=HOUSE_TYPE_CHOICES, default="APT"

--- a/config/settings.py
+++ b/config/settings.py
@@ -91,6 +91,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "apps.pages.context_processors.user_profile",
             ],
         },
     },

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -12,13 +12,14 @@
   <!-- Sidebar -->
   <div class="sidebar">
     <!-- Sidebar user panel (optional) -->
-    <div class="user-panel mt-3 pb-3 mb-3 d-flex">
+  <div class="user-panel mt-3 pb-3 mb-3 d-flex align-items-center">
       <div class="image">
         <img src="{% static 'dist/img/user2-160x160.jpg' %}" class="img-circle elevation-2" alt="User Image">
       </div>
       <div class="info">
         {% if request.user.is_authenticated %}
-          <a href="#" class="d-block">{{request.user.username}}</a>
+          <a href="#" class="d-block">{{ user_display_name|default:request.user.get_full_name|default:request.user.username }}</a>
+          <span class="d-block text-muted small">@{{ request.user.username }}</span>
         {% else %}
           <a href="#" class="d-block">Alexander Pierce</a>
         {% endif %}        


### PR DESCRIPTION
Implement a display of the user's ``display_name``, as stored in the ``UserProfile`` object, alongside a display of the username. The profile image has been centred.

Added context processors to handle the usernames in the templates.

Closes #42

